### PR TITLE
Support for concatenating an Array of filenames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Metalsmith(__dirname)
 ```
 
 #### files
-Type: `String`
-Default: `**/*`
+Type: `String`/ `Array[string]`
+Default: `'**/*'`
 
-This define which files pattern are concerned by the concatenation. It is
-directly passed to [minimatch](https://github.com/isaacs/minimatch).
+This defines which files are concatenated. A string will concatenate files that match the pattern with [minimatch](https://github.com/isaacs/minimatch). An Array will concatenate files matching filespaths listed as strings in the array.
 
 #### output
 Type: `String`

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,9 @@ var minimatch = require('minimatch');
  */
 module.exports = function plugin(options) {
   options = options || {};
-  options.files = (typeof options.files === 'string') ? options.files : '**/*';
+  var validFileOption = (typeof options.files === 'string' || Array.isArray(options.files));
+  options.files = (validFileOption) ? options.files : '**/*';
+
   if (typeof options.output === 'undefined') { throw new Error('Missing `output` option'); }
   options.keepConcatenated = (typeof options.keepConcatenated === 'boolean') ? options.keepConcatenated : false;
 
@@ -18,19 +20,36 @@ module.exports = function plugin(options) {
    * @param {Function} done
    */
   return function(files, metalsmith, done) {
-    var concatenated = '';
-
-    Object.keys(files).forEach(function(filename) {
-      if (!minimatch(filename, options.files)) { return; }
-
-      concatenated += files[filename].contents;
-      if (!options.keepConcatenated) {
-        delete files[filename];
-      }
-    });
-
-    files[options.output] = { contents: concatenated };
-
+    if (Array.isArray(options.files))
+      files[options.output] = { contents: concatArr(options, files) };
+    else
+      files[options.output] = { contents: concatObj(options, files) };
     return done();
   };
 };
+
+/**
+ *  Concatinates file contents based on an Array of filepaths.
+ */
+function concatArr(options, files) {
+  var concatenated = '';
+  options.files.forEach(function(filename){
+    if (!files[filename]) throw new Error(filename + ' does not exist');
+    concatenated += files[filename].contents;
+    if (!options.keepConcatenated) delete files[filename];
+  });
+  return concatenated;
+}
+
+/**
+ *  Concatinates files that match a glob.
+ */
+function concatObj(options, files){
+  var concatenated = '';
+  Object.keys(files).forEach(function(filename) {
+    if (!minimatch(filename, options.files)) { return; }
+    concatenated += files[filename].contents;
+    if (!options.keepConcatenated) delete files[filename];
+  });
+  return concatenated;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-concat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Metalsmith plugin to minify CSS files.",
   "main": "lib/index.js",
   "directories": {
@@ -28,5 +28,8 @@
     "lodash": "^2.4.1",
     "metalsmith": "~0.8.0",
     "mocha": "~1.20.1"
+  },
+  "scripts":{
+    "test": "node_modules/.bin/mocha --reporter spec test/*.js"
   }
 }

--- a/test/metalsmith-concat.js
+++ b/test/metalsmith-concat.js
@@ -75,11 +75,22 @@ describe('metalsmith-concat', function() {
 
 
   it('should throw an error if no output path is given', function(done) {
+    var options = {output: 'output/file/path'};
     expect(function() {
       concat()();
     }).to.throw();
     done();
   });
 
+
+  it('should concat files passed as an Array', function(done) {
+    concat({
+      files: ['first/file', 'third/file'],
+      output: 'output/file/path'
+    })(files, null, function() {
+      expect(files['output/file/path']).to.deep.equal({ contents: 'loremipsum' });
+      done();
+    });
+  });
 
 });

--- a/test/metalsmith-concat.js
+++ b/test/metalsmith-concat.js
@@ -75,7 +75,6 @@ describe('metalsmith-concat', function() {
 
 
   it('should throw an error if no output path is given', function(done) {
-    var options = {output: 'output/file/path'};
     expect(function() {
       concat()();
     }).to.throw();


### PR DESCRIPTION
Users can now pass an Array into the `files` option: 
```javascript
.use(concat{
    files: ['first/files', 'second/file'],
    output: 'styles/app.css'
  }));
```

Let me know what you think.