### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Metalsmith(__dirname)
   .use(concat({
     files: 'styles/**/*.css',
     output: 'styles/app.css'
-  }));
+  }))
   .build();
 ```
 


### PR DESCRIPTION
Small change, there should be no semicolon after `.use()` in the code example, otherwise the function chaining wouldn't work.