### PR TITLE
Add forceOutput option to override existing file check

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,20 @@ article](http://evanhahn.com/newline-necessary-at-the-end-of-javascript-files/))
 It is also possible to pass a string, in which case it will be used instead of
 `\n`.
 
+#### forceOutput
+Type: `Boolean`
+Default: `false`
+
+By default metalsmith-concat throws error if output file already exists. You can 
+disable existing file check by using this option.
+
 ## Changelog
 
+* 3.1.0
+  * It is possible to override existing output file check by setting `options.forceOutput` to true ([#19](https://github.com/aymericbeaumet/metalsmith-concat/issues/19))
+  * Handle metalsmith errors gracefully as described [here](http://www.robinthrift.com/posts/metalsmith-part-3-refining-our-tools/).
+  * Upgrade all dependencies to their latest versions.
+  
 * 3.0.0
   * An array of minimatch patterns can now be passed as `options.files` ([#6](https://github.com/aymericbeaumet/metalsmith-concat/issues/6), [#9](https://github.com/aymericbeaumet/metalsmith-concat/issues/9))
   * File paths are normalized, hence making this plugin working on Windows

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,14 +32,16 @@ module.exports = function (options) {
     typeof options.keepConcatenated === 'boolean' ? options.keepConcatenated :
     false
   options.output = options.output && metalsmithifyPath(options.output)
+  options.forceOutput = !!options.forceOutput
 
   if (typeof options.output !== 'string') {
     throw new Error('`options.output` is mandatory and has to be a string')
   }
 
   return function (files, metalsmith, done) {
-    if (files[options.output]) {
-      throw new Error('The file "' + options.output + '" already exists')
+    if (!options.forceOutput && files[options.output]) {
+      done(new Error('The file "' + options.output + '" already exists'))
+      return
     }
 
     files[options.output] = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-concat",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "A Metalsmith plugin to concatenate files",
   "keywords": [
     "metalsmith",
@@ -16,15 +16,15 @@
     "codeclimate": "codeclimate-test-reporter < coverage/lcov.info"
   },
   "dependencies": {
-    "minimatch": "2.0.10"
+    "minimatch": "3.0.0"
   },
   "devDependencies": {
-    "codeclimate-test-reporter": "0.1.0",
-    "istanbul": "0.3.18",
-    "metalsmith": "2.0.1",
-    "npm-shrinkwrap": "5.4.0",
-    "standard": "4.5.4",
-    "tape": "4.0.1"
+    "codeclimate-test-reporter": "0.1.1",
+    "istanbul": "0.4.1",
+    "metalsmith": "2.1.0",
+    "npm-shrinkwrap": "5.4.1",
+    "standard": "5.4.1",
+    "tape": "4.2.2"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -199,15 +199,36 @@ test('metalsmith-concat', function (t) {
     }
   })
 
-  t.test('should throw an error if options.output already exists', function (q) {
+  t.test('should throw an error if options.output already exists by default', function (q) {
     q.plan(2)
     var plugin = concat({ output: 'output/path' })
-    try {
-      plugin({ 'output/path': {} })
-    } catch (error) {
+    plugin({ 'output/path': {}}, null, function (error) {
       q.ok(error instanceof Error)
       q.deepEqual(error.message, 'The file "output/path" already exists')
+    })
+  })
+
+  t.test('should throw an error if options.output already exists when indicated as option', function (q) {
+    q.plan(2)
+    var plugin = concat({ output: 'output/path', forceOutput: false })
+    plugin({ 'output/path': {}}, null, function (error) {
+      q.ok(error instanceof Error)
+      q.deepEqual(error.message, 'The file "output/path" already exists')
+    })
+  })
+
+  t.test('should override existing file check if forceOutput is enabled', function (q) {
+    q.plan(1)
+    var files = {
+      'output/path1': { contents: 'test123' },
+      'output/path2': { contents: '456test' }
     }
+    var plugin = concat({ files: ['output/path1', 'output/path2'], output: 'output/path', forceOutput: true })
+    plugin(files, null, function () {
+      q.deepEqual(files, {
+        'output/path': { contents: 'test123\n456test\n' }
+      })
+    })
   })
 
   // https://github.com/aymericbeaumet/metalsmith-concat/issues/9


### PR DESCRIPTION
This PR contains following changes:

1. Fix for #19. Users may use `forceOutput` option to override existing file check.
2. Handling error in metalsmith pipeline gracefully: In metalsmith, errors shouldn't be thrown, instead, `done()` callback should be called with a meaningful `Error` object as described [here](http://www.robinthrift.com/posts/metalsmith-part-3-refining-our-tools/).
3. Upgrade all dependencies to their latest version. 