### PR TITLE
Fix Windows implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 language: node_js
 node_js:
   - node

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ const async = require('async');
 const glob = require('glob');
 const minimatch = require('minimatch');
 
-// Must be called to clean the glob/minimatch inputs and patterns as they only
-// support forward slashes (see: https://github.com/isaacs/node-glob#windows)
+// Must be called to convert the glob/minimatch inputs and patterns to the
+// forward slash path notation (see:
+// https://github.com/isaacs/node-glob#windows)
 function backslashToSlash(s) {
 	return s.replace(/\\/g, '/');
 }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = (options = {}) => {
 		(typeof options.searchPaths === 'string' ?
 			[options.searchPaths] :
 			[])
-	).map(sp => backslashToSlash(sp));
+	);
 
 	const {forceOutput = false, keepConcatenated = false} = options;
 
@@ -115,7 +115,11 @@ module.exports = (options = {}) => {
 			(acc, pattern) => [
 				...acc,
 				gathererFromSourceDirectory(files, pattern, {keepConcatenated}),
-				gathererFromSearchPaths(backslashToSlash(metalsmith._directory), searchPaths, pattern)
+				gathererFromSearchPaths(
+					backslashToSlash(metalsmith._directory),
+					searchPaths.map(sp => backslashToSlash(sp)),
+					pattern
+				)
 			],
 			[]
 		);

--- a/index.js
+++ b/index.js
@@ -5,15 +5,15 @@ const glob = require('glob');
 const minimatch = require('minimatch');
 
 // Must be called to convert the glob/minimatch inputs and patterns to the
-// forward slash path notation (see:
-// https://github.com/isaacs/node-glob#windows)
+// forward slash path notation
+// (see: https://github.com/isaacs/node-glob#windows)
 function backslashToSlash(s) {
 	return s.replace(/\\/g, '/');
 }
 
 // Source and pattern are expected to be in the forward slash form
 function gathererFromSourceDirectory(source, pattern, {keepConcatenated}) {
-	// This gather loops over all the files Metalsmith knows of and return an
+	// This gatherer loops over all the files Metalsmith knows of and return an
 	// array of all the files contents matching the given pattern. Before the
 	// filepaths are matched, they are normalized to the forward slash form.
 	return function (done) {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function gathererFromSearchPaths(rootPath, searchPaths, pattern) {
 						}
 
 						async.map(
-							filepaths.map(filepath => path.normalize(path.resolve(rootPath, filepath))),
+							filepaths.map(filepath => path.resolve(rootPath, filepath)),
 							fs.readFile,
 							callback
 						);
@@ -94,12 +94,11 @@ module.exports = (options = {}) => {
 			'' :
 			'\n');
 
-	const searchPaths = (Array.isArray(options.searchPaths) ?
+	const searchPaths = Array.isArray(options.searchPaths) ?
 		options.searchPaths :
 		(typeof options.searchPaths === 'string' ?
 			[options.searchPaths] :
-			[])
-	);
+			[]);
 
 	const {forceOutput = false, keepConcatenated = false} = options;
 

--- a/index.js
+++ b/index.js
@@ -10,10 +10,11 @@ function backslashToSlash(s) {
 	return s.replace(/\\/g, '/');
 }
 
+// Source and pattern are expected to be in the forward slash form
 function gathererFromSourceDirectory(source, pattern, {keepConcatenated}) {
 	// This gather loops over all the files Metalsmith knows of and return an
 	// array of all the files contents matching the given pattern. Before the
-	// filepaths are matched, they are normalized so that the \ become /.
+	// filepaths are matched, they are normalized to the forward slash form.
 	return function (done) {
 		return done(
 			null,
@@ -31,6 +32,7 @@ function gathererFromSourceDirectory(source, pattern, {keepConcatenated}) {
 	};
 }
 
+// RootPath, searchPaths and pattern are expected to be in the forward slash form
 function gathererFromSearchPaths(rootPath, searchPaths, pattern) {
 	// This gatherer loops over the search paths and return an array of all the files
 	// contents matching the given pattern

--- a/readme.md
+++ b/readme.md
@@ -58,10 +58,10 @@ Type: `string | string[]`
 Default: `['**/*']`
 
 This defines which files are concatenated. This string will be interpreted as a
-[minimatch](https://github.com/isaacs/minimatch) pattern. An array of strings
-will be interpreted as distinct minimatch patterns, in this case the order of
-the patterns matters (it will determine the order in which the files are
-concatenated).
+[minimatch](https://github.com/isaacs/minimatch) pattern. **It is mandatory to
+use forward slashes, even on Windows.** An array of strings will be interpreted
+as distinct minimatch patterns, in this case the order of the patterns matters
+(it will determine the order in which the files are concatenated).
 
 _Note: during the search, these patterns will be evaluated relativetly to
 both the source path and the [search
@@ -73,7 +73,8 @@ paths](https://github.com/aymericbeaumet/metalsmith-concat#optionssearchpaths)
 Type: `string`
 
 It represents the filepath where the concatenated content will be outputted.
-This option is **mandatory**.
+This option is **mandatory**. You are free to use `/` or `\` path delimitors
+for this option.
 
 _Note: this is relative to the destination path._
 
@@ -115,7 +116,8 @@ Default: `[]`
 Specify additional paths to search. The paths are resolved relatively to
 Metalsmith's root directory. Absolute paths are also supported. An ignore
 pattern is applied on the results to make sure the `src` directory is not
-matched twice from a custom search path.
+matched twice from a custom search path. You are free to use `/` or `\` path
+delimitors for this option.
 
 ## FAQ
 

--- a/readme.md
+++ b/readme.md
@@ -59,9 +59,10 @@ Default: `['**/*']`
 
 This defines which files are concatenated. This string will be interpreted as a
 [minimatch](https://github.com/isaacs/minimatch) pattern. **It is mandatory to
-use forward slashes, even on Windows.** An array of strings will be interpreted
-as distinct minimatch patterns, in this case the order of the patterns matters
-(it will determine the order in which the files are concatenated).
+use forward slashes for this specific option, even on Windows.** An array of
+strings will be interpreted as distinct minimatch patterns, in this case the
+order of the patterns matters (it will determine the order in which the files
+are concatenated).
 
 _Note: during the search, these patterns will be evaluated relativetly to
 both the source path and the [search
@@ -73,8 +74,7 @@ paths](https://github.com/aymericbeaumet/metalsmith-concat#optionssearchpaths)
 Type: `string`
 
 It represents the filepath where the concatenated content will be outputted.
-This option is **mandatory**. You are free to use `/` or `\` path delimitors
-for this option.
+This option is **mandatory**.
 
 _Note: this is relative to the destination path._
 
@@ -116,8 +116,7 @@ Default: `[]`
 Specify additional paths to search. The paths are resolved relatively to
 Metalsmith's root directory. Absolute paths are also supported. An ignore
 pattern is applied on the results to make sure the `src` directory is not
-matched twice from a custom search path. You are free to use `/` or `\` path
-delimitors for this option.
+matched twice from a custom search path.
 
 ## FAQ
 

--- a/test.js
+++ b/test.js
@@ -462,7 +462,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.deepEqual(files.output.contents, Buffer.from('anotherdir\n\nroot\n\n'));
+			t.is(files.output.contents.toString(), 'anotherdir\n\nroot\n\n');
 			t.end();
 		});
 	}
@@ -480,7 +480,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.deepEqual(files.output.contents, Buffer.from('anotherdir\n\nroot\n\n'));
+			t.is(files.output.contents.toString(), 'anotherdir\n\nroot\n\n');
 			t.end();
 		});
 	}

--- a/test.js
+++ b/test.js
@@ -436,28 +436,6 @@ test.cb(
 	}
 );
 
-// https://github.com/aymericbeaumet/metalsmith-concat/issues/8
-test.cb(
-	'metalsmith-concat should normalize options.output and options.files to be cross-platform compatible',
-	t => {
-		t.plan(2);
-		const files = {
-			'js/jquery.js': {contents: Buffer.from('jquery')}
-		};
-		const plugin = metalsmithConcat({
-			files: ['js\\jquery.js'],
-			output: 'js\\app.js'
-		});
-		plugin(files, metalsmithFixture(), error => {
-			t.falsy(error);
-			t.deepEqual(files, {
-				'js/app.js': {contents: Buffer.from('jquery\n')}
-			});
-			t.end();
-		});
-	}
-);
-
 test.cb(
 	'metalsmith-concat should not include files from options.searchPaths by default',
 	t => {
@@ -466,7 +444,7 @@ test.cb(
 		const plugin = metalsmithConcat({files: ['**/*.md'], output: 'output'});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.true(files.output.contents.equals(Buffer.from('')));
+			t.deepEqual(files.output.contents, Buffer.from(''));
 			t.end();
 		});
 	}
@@ -484,9 +462,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.true(
-				files.output.contents.equals(Buffer.from('anotherdir\n\nroot\n\n'))
-			);
+			t.deepEqual(files.output.contents, Buffer.from('anotherdir\n\nroot\n\n'));
 			t.end();
 		});
 	}
@@ -504,9 +480,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.true(
-				files.output.contents.equals(Buffer.from('anotherdir\n\nroot\n\n'))
-			);
+			t.deepEqual(files.output.contents, Buffer.from('anotherdir\n\nroot\n\n'));
 			t.end();
 		});
 	}
@@ -570,22 +544,42 @@ test.cb(
 	}
 );
 
-// https://github.com/aymericbeaumet/metalsmith-concat/issues/26
 test.cb(
-	'metalsmith-concat should simplify the given path in the pattern',
+	'metalsmith-concat should support unix style "/" delimiter',
 	t => {
 		t.plan(2);
 		const files = {
-			'foo/bar/baz': {contents: Buffer.from('foobarbaz')}
+			'js/jquery.js': {contents: Buffer.from('jquery')}
 		};
 		const plugin = metalsmithConcat({
-			files: 'foo//\\\\bar\\\\//baz',
-			output: 'output/path'
+			files: ['js/jquery.js'],
+			output: 'js/app.js'
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
 			t.deepEqual(files, {
-				'output/path': {contents: Buffer.from('foobarbaz\n')}
+				'js/app.js': {contents: Buffer.from('jquery\n')}
+			});
+			t.end();
+		});
+	}
+);
+
+test.cb(
+	'metalsmith-concat should support windows style "\\" delimiter (even with "/" in pattern)',
+	t => {
+		t.plan(2);
+		const files = {
+			'js\\jquery.js': {contents: Buffer.from('jquery')}
+		};
+		const plugin = metalsmithConcat({
+			files: ['js/jquery.js'],
+			output: 'js\\app.js'
+		});
+		plugin(files, metalsmithFixture(), error => {
+			t.falsy(error);
+			t.deepEqual(files, {
+				'js\\app.js': {contents: Buffer.from('jquery\n')}
 			});
 			t.end();
 		});

--- a/test.js
+++ b/test.js
@@ -444,7 +444,7 @@ test.cb(
 		const plugin = metalsmithConcat({files: ['**/*.md'], output: 'output'});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.deepEqual(files.output.contents, Buffer.from(''));
+			t.is(files.output.contents.toString(), '');
 			t.end();
 		});
 	}

--- a/test.js
+++ b/test.js
@@ -462,7 +462,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.is(files.output.contents.toString(), 'anotherdir\n\nroot\n\n');
+			t.is(files.output.contents.toString().replace(/\/r\n/g, '\n'), 'anotherdir\n\nroot\n\n');
 			t.end();
 		});
 	}
@@ -480,7 +480,7 @@ test.cb(
 		});
 		plugin(files, metalsmithFixture(), error => {
 			t.falsy(error);
-			t.is(files.output.contents.toString(), 'anotherdir\n\nroot\n\n');
+			t.is(files.output.contents.toString().replace(/\/r\n/g, '\n'), 'anotherdir\n\nroot\n\n');
 			t.end();
 		});
 	}


### PR DESCRIPTION
This PR implements a more robust strategy to make this lib platform agnostic:
- no longer convert everything to `/` notation
- glob patterns are expected to be provided in the `/` (forward slash) form as this is what globby expects (they deal with the portability). I don't want to support the `\\` form and replace with `/` as this seems fragile
- `options.files` and `options.searchPaths` are free to be defined with `/` or `\\` notation

The tests are also now run on Windows as part of the CI process.
